### PR TITLE
fix: update bundler version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.4.1
-before_install: gem install bundler -v 1.17.1
+  - 2.4
+  - 2.5
+  - 2.6
+before_install: gem install bundler -v '~> 2.0'


### PR DESCRIPTION
Right now `.travis.yml` installs version of bundler gem witch incompatible with requirements in the gem specification. This should fix it.